### PR TITLE
Custom printer, with default fallback to previous `print`

### DIFF
--- a/alamofire_activity_logger/ActivityLogger/LoggeableRequest.swift
+++ b/alamofire_activity_logger/ActivityLogger/LoggeableRequest.swift
@@ -32,6 +32,9 @@ public enum LogLevel {
     case error
 }
 
+public typealias Printer = (String) -> Void
+public let defaultPrinter: Printer = { print($0) }
+
 /**
  Login options
  
@@ -84,7 +87,7 @@ public extension LoggeableRequest {
     /**
      Log the request and response with the given level and options
      */
-    public func log(level: LogLevel = .all, options: [LogOption] = LogOption.defaultOptions) -> Self {
+    public func log(level: LogLevel = .all, options: [LogOption] = LogOption.defaultOptions, printer: @escaping Printer = defaultPrinter) -> Self {
         
         guard level != .none else {
             return self
@@ -95,9 +98,9 @@ public extension LoggeableRequest {
             return self
         }
         
-        Logger.logRequest(request: request, level: level, options: options)
+        Logger.logRequest(request: request, level: level, options: options, printer: printer)
         fetchResponseInfo { response in
-            Logger.logResponse(request: self.request, response: response, level: level, options: options)
+            Logger.logResponse(request: self.request, response: response, level: level, options: options, printer: printer)
         }
         
         return self

--- a/alamofire_activity_logger/ActivityLogger/Logger.swift
+++ b/alamofire_activity_logger/ActivityLogger/Logger.swift
@@ -52,7 +52,7 @@ internal struct Logger {
         return response
     }
     
-    internal static func logRequest(request: URLRequest?, level: LogLevel, options: [LogOption]) {
+    internal static func logRequest(request: URLRequest?, level: LogLevel, options: [LogOption], printer: Printer) {
         
         guard let request = request else {
             return
@@ -70,17 +70,17 @@ internal struct Logger {
         case .all:
             let prettyPrint = options.contains(.jsonPrettyPrint)
             let body = string(from: request.httpBody, prettyPrint: prettyPrint) ?? nullString
-            print("\(openSeparator)[Request] \(method) '\(url)':\n\n[Headers]\n\(headers)\n\n[Body]\n\(body)\(closeSeparator)")
+            printer("\(openSeparator)[Request] \(method) '\(url)':\n\n[Headers]\n\(headers)\n\n[Body]\n\(body)\(closeSeparator)")
             
         case .info:
-            print("\(openSeparator)[Request] \(method) '\(url)'\(closeSeparator)")
+            printer("\(openSeparator)[Request] \(method) '\(url)'\(closeSeparator)")
             
         default:
             break
         }
     }
     
-    internal static func logResponse(request: URLRequest?, response: ResponseInfo, level: LogLevel, options: [LogOption]) {
+    internal static func logResponse(request: URLRequest?, response: ResponseInfo, level: LogLevel, options: [LogOption], printer: Printer) {
         
         guard level != .none else {
             return
@@ -118,12 +118,12 @@ internal struct Logger {
         let responseTitle = error == nil ? "Response" : "Response Error"
         switch level {
         case .all:
-            print("\(openSeparator)[\(responseTitle)] \(responseStatusCode) '\(requestUrl)' \(elapsedTimeString):\n\n[Headers]:\n\(responseHeaders)\n\n[Body]\n\(responseData)\(closeSeparator)")
+            printer("\(openSeparator)[\(responseTitle)] \(responseStatusCode) '\(requestUrl)' \(elapsedTimeString):\n\n[Headers]:\n\(responseHeaders)\n\n[Body]\n\(responseData)\(closeSeparator)")
         case .info:
-            print("\(openSeparator)[\(responseTitle)] \(responseStatusCode) '\(requestUrl)' \(elapsedTimeString)\(closeSeparator)")
+            printer("\(openSeparator)[\(responseTitle)] \(responseStatusCode) '\(requestUrl)' \(elapsedTimeString)\(closeSeparator)")
         case .error:
             if let error = error {
-                print("\(openSeparator)[\(responseTitle)] \(requestMethod) '\(requestUrl)' \(elapsedTimeString) s: \(error)\(closeSeparator)")
+                printer("\(openSeparator)[\(responseTitle)] \(requestMethod) '\(requestUrl)' \(elapsedTimeString) s: \(error)\(closeSeparator)")
             }
         default:
             break


### PR DESCRIPTION
Hi,

Nice work here! I wanted to forward the logs to my custom logger, so made a few modifications. Basically to be able to provide a custom printer (previous implementation is still a default).

It is backward compatible, so anyone using it can still call do:
```
.log(level: .info, options: [.onlyDebug])
.responseJSON { response in
// ....
}
```

Yet for those of us with a custom logger (I am using SwiftyBeaver in combination with Fabric), you may do:
```
.log(level: .info, options: [.onlyDebug]) { logger.info($0) }
.responseJSON { response in
// ....
}
```

Hope it helps. Let me know if you feel anything should be updated.

Cheers,
H.
